### PR TITLE
Fix use of juce::Result. ok() -> wasOk().

### DIFF
--- a/jucey_bonjour/bonjour/jucey_BonjourService.cpp
+++ b/jucey_bonjour/bonjour/jucey_BonjourService.cpp
@@ -429,7 +429,7 @@ namespace jucey
                                                             &Pimpl::browseReply,
                                                             this))};
 
-        if (result.ok())
+        if (result.wasOk())
             pimpl->startDnsService (ref);
 
         return result;
@@ -449,7 +449,7 @@ namespace jucey
                                                              &Pimpl::resolveReply,
                                                              this))};
 
-        if (result.ok())
+        if (result.wasOk())
             pimpl->startDnsService (ref);
 
         return result;
@@ -478,7 +478,7 @@ namespace jucey
                                                               &Pimpl::registerReply,
                                                               this))};
 
-        if (result.ok())
+        if (result.wasOk())
             pimpl->startDnsService (ref);
 
         return result;


### PR DESCRIPTION
ok() is to create a new OK status. To check status, wasOk() is the right one.